### PR TITLE
Unmount react components when component is being stoped

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -8,6 +8,7 @@ function start(options) {
     ReactDOM.render(<Example/>, el);
     return Promise.resolve({
         stop: () => {
+            ReactDOM.unmountComponentAtNode(el);
             console.log('stopped');
             return Promise.resolve();
         }


### PR DESCRIPTION
Hey!

I would propose this change, because React components has to be unmounted when the custom script is being stopped.