### PR TITLE
fix Invalid Host Header in dev environment

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
     devServer: {
         contentBase: path.resolve(__dirname, 'dist'),
         compress: true,
+        disableHostCheck: true,
         port: 8080,
         https: true,
         headers: {


### PR DESCRIPTION
Since a couple of days the dev environment was logging `Invalid Host Header` errors in the console which was related to this issue. /also the live reload was broken/ 
We did not experience this on other projects, I guess it's related to the self signed certificate and some node module change in the near past. 
With this flag the error disappears, and the live reload works again 👍 

