### PR TITLE
fix(webpack) remove AMD module name

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,6 @@ module.exports = {
     entry: './src/main/index.js',
     mode: 'development',
     output: {
-        library: 'customScript',
         libraryTarget: 'amd',
         path: path.resolve(__dirname, 'dist'),
         filename: 'bundle.js'


### PR DESCRIPTION
If you want to use a custom script with requirejs you have to know the module name beforehand.
In addition to that, it should also be unique, which we can't ensure.

Ref: RBCOM-2002