### PR TITLE
fix(webpack): adds library name again

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
     entry: './src/main/index.js',
     mode: 'development',
     output: {
+        library: 'customScript',
         libraryTarget: 'amd',
         path: path.resolve(__dirname, 'dist'),
         filename: 'bundle.js'


### PR DESCRIPTION
loading production builds without name fails, thats why we added it.
it was removed as a preparation for requirejs, which we won't use anyways